### PR TITLE
fix daemonSet

### DIFF
--- a/helm/encryption-config-hasher/templates/daemonSet.yaml
+++ b/helm/encryption-config-hasher/templates/daemonSet.yaml
@@ -13,7 +13,7 @@ spec:
   updateStrategy:
     rollingUpdate:
       maxSurge: 1
-      maxUnavailable: 1
+      maxUnavailable: 0
     type: RollingUpdate
   template:
     metadata:


### PR DESCRIPTION
Installation of this app fails with this error

```
    Reason: Upgrade "encryption-config-hasher" failed: failed to create resource: DaemonSet.apps "encryption-config-hasher" is invalid: spec.updateStrategy.rollingUpdate.maxSurge: Invalid value: intstr.IntOrString{Type:0, IntVal:1, StrVal:""}: may not be set when maxUnavailable is non-zero
```

indeed, documentation is clear about this https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/daemon-set-v1/#DaemonSetSpec

this PR fixed it